### PR TITLE
Fetching with paging and stricter stopwords.

### DIFF
--- a/src/service.py
+++ b/src/service.py
@@ -1,3 +1,4 @@
+import logging
 import string
 import tweepy
 
@@ -11,7 +12,7 @@ class Service(object):
     # Map uppercase to lowercase, and deletes any punctuation.
     trans = {ord(string.ascii_uppercase[i]): ord(string.ascii_lowercase[i])
              for i in range(26)}
-    trans.update({ord(c): None for c in string.punctuation + string.digits})
+    trans.update({ord(c): None for c in string.punctuation})
 
     def __init__(self, access_token='', access_token_secret=''):
         self._tw_api = None
@@ -28,17 +29,35 @@ class Service(object):
         return self._tw_api
 
     def fetch(self, query, limit=100):
-        """Fetches search results for the given query.
-
-        TODO(kanat): Figure out why result_type='popular' results < limit.
-        """
-        #return list(tweepy.Cursor(
-        #    self.tw_api.search,
-        #    q=query,
-        #    lang='en',
-        #    result_type='popular').items(limit))
-        return self.tw_api.search(q=query, count=limit,
-                                  result_type='popular', lang='en')
+        """Fetches search results for the given query."""
+        # Cursor doesn't work with dev_appserver.py :(
+        # return list(tweepy.Cursor(self.tw_api.search, q=query, lang='en',
+        #                          result_type='popular').items(limit))
+        query += ' -filter:retweets'
+        # Try to get as many 'popular' posts as possible.
+        # Twitter limits this really hard.
+        res_type = 'popular'
+        last_id = -1
+        tweets = []
+        while len(tweets) < limit:
+            count = limit - len(tweets)
+            try:
+                t = self.tw_api.search(q=query, count=count, result_type=res_type,
+                                       lang='en', max_id=str(last_id - 1))
+                if len(t) < 3 and res_type == 'popular':
+                    tweets.extend(t)
+                    res_type = 'mixed'
+                    last_id = -1
+                    continue
+                if len(t) < 3 and res_type == 'mixed':
+                    tweets.extend(t)
+                    break
+                tweets.extend(t)
+                last_id = t[-1].id
+            except tweepy.TweepError as e:
+                logging.exception(e)
+                break
+        return tweets
 
     @staticmethod
     def top_hashtags(tweets, limit=5):
@@ -52,15 +71,19 @@ class Service(object):
         return ['#' + t[0] for t in top]
 
     @staticmethod
-    def top_keywords(tweets, limit=5):
-        """Extracts most frequent keywords from given tweets.
-
-        TODO(kanat): Use stopwords. Refer to _token_okay().
-        """
+    def top_keywords(tweets, limit=5, exclude=set()):
+        """Extracts most frequent keywords from given tweets."""
+        exc = set()
+        for w in exclude:
+            ok, text = _token_okay(w)
+            if ok:
+                exc.add(text)
         words = Counter()
         for t in tweets:
             for token in set(t.text.split()):
-                words[token.lower()] += 1
+                ok, text = _token_okay(token)
+                if ok and text not in exc:
+                    words[text] += 1
         top = words.most_common(limit)
         return [t[0] for t in top]
 
@@ -68,7 +91,11 @@ class Service(object):
 def _token_okay(text):
     """Decides whether the given token is a valid expandable query."""
     text = ''.join(c for c in text if 127 > ord(c) > 31)
-    text = text.translate(Service.trans)
-    if len(text) < 3 or Stopword.gql('WHERE token = :1', text).get() is not None:
-        return False
-    return True
+    try:
+        text = text.translate(Service.trans)
+    except TypeError:
+        return False, text
+    if (len(text) < 2 or text.isdigit()
+            or Stopword.gql('WHERE token = :1', text).get() is not None):
+        return False, text
+    return True, text


### PR DESCRIPTION
`tweepy.Cursor` doesn't work on the development server for some reason so I had to roll out my own "paging". 

`service.fetch()` now tries to grab 'popular' tweets first, then 'mixed'.