### PR TITLE
Query expansion experiments.

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -11,28 +11,26 @@ class Status(messages.Enum):
     Cancelled = 3
 
 
+class Method(ndb.Model):
+    """Experiment method."""
+    qid = ndb.IntegerProperty()
+    version = ndb.IntegerProperty()
+    query = ndb.StringProperty()
+    status_ids = ndb.IntegerProperty(repeated=True)
+
+
 class Query(ndb.Model):
     """Query details."""
     query = ndb.StringProperty()
+    uid = ndb.IntegerProperty(indexed=False)
     email = ndb.StringProperty(indexed=False)
-    equery = ndb.IntegerProperty()
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=False)
-    updated = ndb.DateTimeProperty(auto_now=True, indexed=False)
+    updated = ndb.DateTimeProperty(auto_now=True)
     status = msgprop.EnumProperty(Status, default=Status.Pending)
-    status_msg = ndb.StringProperty()
-
-
-class ExpandedQuery(ndb.Model):
-    """Expanded queries."""
-    qid = ndb.IntegerProperty()
-    # Tweet IDs from the original query.
-    basic_results = ndb.IntegerProperty(repeated=True, indexed=False)
-    # Expanded query: hashtags.
-    hashtags = ndb.StringProperty(repeated=True)
-    hashtag_results = ndb.IntegerProperty(repeated=True, indexed=False)
-    # Expanded query: keywords.
-    keywords = ndb.StringProperty(repeated=True)
-    keyword_results = ndb.IntegerProperty(repeated=True, indexed=False)
+    status_msg = ndb.StringProperty(indexed=False)
+    hashtags = ndb.StringProperty(repeated=True, indexed=False)
+    keywords = ndb.StringProperty(repeated=True, indexed=False)
+    methods = ndb.KeyProperty(kind=Method, repeated=True)
 
 
 class Stopword(ndb.Model):
@@ -40,7 +38,9 @@ class Stopword(ndb.Model):
 
 
 class Feedback(ndb.Model):
-    """Feedback for a particular query. 1: relevant, 0: neutral 1: irrelevant"""
+    """Feedback for a particular query.
+        1: interesting, 0: neutral -1: not interesting.
+    """
     qid = ndb.IntegerProperty()
     uid = ndb.IntegerProperty()
     sid = ndb.IntegerProperty()

--- a/src/tqueue.py
+++ b/src/tqueue.py
@@ -2,8 +2,10 @@ import logging
 import service
 import webapp2
 
-from models import (Query, ExpandedQuery, Status)
+from models import (Query, Status, Method)
+from collections import Counter
 from google.appengine.api import mail
+from google.appengine.ext import ndb
 
 
 class QueueHandler(webapp2.RequestHandler):
@@ -18,10 +20,6 @@ class QueueHandler(webapp2.RequestHandler):
             logging.warning('Query not pending. qid={}'.format(qid))
             return
         logging.info('Queue pop: {}'.format(qid))
-        if not result.equery:
-            equery = ExpandedQuery(qid=qid)
-            equery.put()
-            result.equery = equery.key.id()
         result.status = Status.Working
         result.put()
         try:
@@ -42,32 +40,76 @@ def expand_query(qid, auth_info):
     TODO(kanat): Clean this shit up.
     """
     result = Query.get_by_id(qid)
+    q = result.query
     serv = service.Service(auth_info[0], auth_info[1])
-    basic_results = serv.fetch(result.query, limit=100)
+    tweets = serv.fetch(result.query, limit=195)
+    hashtags = serv.top_hashtags(tweets, limit=10)
+    keywords = serv.top_keywords(tweets, limit=10, exclude=set(q.split()))
 
-    hashtags = serv.top_hashtags(basic_results, limit=2)
-    keywords = serv.top_keywords(basic_results, limit=2)
+    methods = []
 
-    h1 = serv.fetch(hashtags[0], limit=4)
-    h2 = serv.fetch(hashtags[1], limit=4)
+    # Method-0: q
+    if tweets:
+        methods.append(Method(qid=qid, version=0, query=q,
+                              status_ids=_extract_ids(tweets[:10])))
+    # Method-1: q + h'
+    if hashtags:
+        q1 = q + ' ' + hashtags[0]
+        m1 = serv.fetch(q1, limit=10)
+        if m1:
+            methods.append(Method(qid=qid, version=1, query=q1,
+                                  status_ids=_extract_ids(m1)))
+    # Method-2: q + k'
+    if keywords:
+        q2 = q + ' ' + keywords[0]
+        m2 = serv.fetch(q2, limit=10)
+        if m2:
+            methods.append(Method(qid=qid, version=2, query=q2,
+                                  status_ids=_extract_ids(m2)))
+    # Method-3: q + h' + k'
+    if hashtags and keywords:
+        q3 = q + ' ' + hashtags[0] + ' ' + keywords[0]
+        m3 = serv.fetch(q3, limit=10)
+        if m3:
+            methods.append(Method(qid=qid, version=3, query=q3,
+                                  status_ids=_extract_ids(m3)))
+    # Method-4: q + h' + h''
+    if len(hashtags) > 1:
+        q4 = q + ' ' + hashtags[0] + ' ' + hashtags[1]
+        m4 = serv.fetch(q4, limit=10)
+        if m4:
+            methods.append(Method(qid=qid, version=4, query=q4,
+                                  status_ids=_extract_ids(m4)))
+    # Method-5: q + k' + k''
+    if len(keywords) > 1:
+        q5 = q + ' ' + keywords[0] + ' ' + keywords[1]
+        m5 = serv.fetch(q5, limit=10)
+        if m5:
+            methods.append(Method(qid=qid, version=5, query=q5,
+                                  status_ids=_extract_ids(m5)))
+    # Method-6: (q + h' OR q + k') => sort by max-matching h and k
+    if hashtags and keywords:
+        q6 = '{} {} OR {} {}'.format(q, hashtags[0], q, keywords[0])
+        m6 = serv.fetch(q6, limit=195)
+        counter = Counter()
+        for tweet in m6:
+            for token in set(tweet.text.split()):
+                ok, text = service._token_okay(token)
+                if ok and (text in hashtags or text in keywords):
+                    counter[tweet.id] += 1
+        m6 = counter.most_common(10)
+        if m6:
+            methods.append(Method(qid=qid, version=6, query='q6',
+                                  status_ids=[k for k, v in m6]))
 
-    k1 = serv.fetch(keywords[0], limit=4)
-    k2 = serv.fetch(keywords[1], limit=4)
+    method_keys = ndb.put_multi(methods)
+    result.hashtags = hashtags
+    result.keywords = keywords
+    result.methods = method_keys
 
-    equery = ExpandedQuery.get_by_id(result.equery)
-    equery.hashtags = hashtags
-    equery.keywords = keywords
-    for r in basic_results:
-        equery.basic_results.append(r.id)
-    for r in h1:
-        equery.hashtag_results.append(r.id)
-    for r in h2:
-        equery.hashtag_results.append(r.id)
-    for r in k1:
-        equery.keyword_results.append(r.id)
-    for r in k2:
-        equery.keyword_results.append(r.id)
-    equery.put()
+
+def _extract_ids(tweets):
+    return [t.id for t in tweets]
 
 
 def notify(qid):


### PR DESCRIPTION
Minor:
- Error handling on some API methods
- Some refactoring
- Exclude `email` and `uid` from the response to the client
- json encode for `ndb.Key`

Major:
- Removed `ExpandedQuery` model. Instead, we have the notion of "method" so that each query can experiment with different methods.
- Added 6 experiment methods (see comments in `tqueue.expand_query()`
- Return top-5 results of each experiment in the `result` API
